### PR TITLE
Remove unnecessary OMP pragma from sqrt_a.c

### DIFF
--- a/gnfs/sqrt/sqrt_a.c
+++ b/gnfs/sqrt/sqrt_a.c
@@ -341,15 +341,8 @@ static void multiply_relations(relation_prod_t *prodinfo,
 		   half and the last half of the relations */
 
 		uint32 mid = (index1 + index2) / 2;
-#pragma omp parallel
-#pragma omp single
-		{
-#pragma omp task
 		multiply_relations(prodinfo, index1, mid, &prod1);
-#pragma omp task
 		multiply_relations(prodinfo, mid + 1, index2, &prod2);
-#pragma omp taskwait
-		}
 	}
 
 	/* multiply them together and save the result */


### PR DESCRIPTION
This provides a speedup / memory leak fix (#3) to Square Root.

Test case 1 (1 dependency):
master: 80s
try_openmp: 65s
pr: 57s

Test case 2 (11 dependencies):
master: 00:14:40
try_openmp: Out of memory
pr: 00:09:48